### PR TITLE
feat: add address filtering

### DIFF
--- a/backend/src/views.py
+++ b/backend/src/views.py
@@ -301,6 +301,10 @@ class ExternalDataViewSet(viewsets.ViewSet):
             response.raise_for_status()
             data = response.json()
             result = data.get('features')
+            result = [ f for f in result if (
+                    f.get("geometry") is not None and
+                    f["geometry"].get("type") == "Point" and
+                    "nombreCalle" in f.get("properties", {}))]
             return Response(result)
         except NotFound:
             raise


### PR DESCRIPTION
Filtra las direcciones de API_GEO1 para evitar errores en caso de direcciones sin coordenadas o sin nombre.